### PR TITLE
Remove extra command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ To start local development, install and run the following commands:
 ``` bash
 $ cp sample.env .env
 $ npm install
-$ npm start
 ```
 
 ## Develop Workflow


### PR DESCRIPTION
`npm install` has a post-command that does the same thing as `npm start` (should actually probably just be `"postinstall": "npm start"`)
